### PR TITLE
Minor edits to fix small regex issues and documentation

### DIFF
--- a/eg/navel_fate
+++ b/eg/navel_fate
@@ -33,4 +33,4 @@ navel_fate - navel fate?
 
 =head1 DESCRIPTION
 
-This document is comming from http://docopt.org/.
+This document is coming from http://docopt.org/.

--- a/lib/Docopt.pm
+++ b/lib/Docopt.pm
@@ -1247,6 +1247,17 @@ It's Docopt documentation.
 
 If you don't provide this argument, Docopt.pm uses pod SYNOPSIS section in $0.
 
+If you use pod documentation SYNOPSIS section be sure to
+
+B<***** indent at least 4 spaces *****>
+
+to prevent combining multiple lines into a paragraph, and watch out for column
+wrap.  You can use perldoc ./program to check the results that are sent into
+Docopt.pm.
+
+If you don't like the format then you should pass it through the "doc"
+argument instead.
+
 =item argv
 
 Argument in arrayref.

--- a/lib/Docopt.pm
+++ b/lib/Docopt.pm
@@ -381,7 +381,7 @@ sub match {
     ref($c) eq 'ARRAY' or Carp::confess("c is not arrayref: " . join(', ', @{$self->children}));
     return (true, $l, $c);
 
-    
+
 #   def match(self, left, collected=None):
 #       collected = [] if collected is None else collected
 #       l = left
@@ -692,7 +692,7 @@ sub parse_long {
                 if (
                     (not defined $tokens->current() ) || $tokens->current eq '--') {
                     $tokens->error->throw(sprintf "%s requires argument", $o->long);
-                } 
+                }
                 $value = $tokens->move;
             }
         }

--- a/lib/Docopt.pm
+++ b/lib/Docopt.pm
@@ -255,9 +255,7 @@ package Docopt::BranchPattern;
 use parent -norequire, qw(Docopt::Pattern);
 
 use Carp;
-
 use Docopt::Util qw(repl class_name);
-use Scalar::Util qw(blessed);
 
 sub new {
     my ($class, $children) = @_;

--- a/lib/Docopt.pm
+++ b/lib/Docopt.pm
@@ -978,7 +978,7 @@ sub parse_defaults {
     for my $s (parse_section('options:', $doc)) {
         # FIXME corner case "bla: options: --foo"
         (undef, undef, $s) = string_partition($s, ':');
-        my @split = split /\n *(-\S+?)/, "\n" . $s;
+        my @split = split /\n[ \t]*(-\S+?)/, "\n" . $s;
         shift @split;
         my @split2;
         for (my $i=0; $i<@split; $i+=2) {

--- a/lib/Docopt.pm
+++ b/lib/Docopt.pm
@@ -323,7 +323,7 @@ sub parse {
     my ($class, $source) = @_;
     $source =~ /(<\S*?>)/;
     my $name = $1;
-    $source =~ /\[default: (.*)\]/i;
+    $source =~ /\[default: (.*?)\]/i;
     my $value = $1;
     return $class->new($name, $value);
 }
@@ -635,7 +635,7 @@ sub parse {
         }
     }
     if ($argcount) {
-        if (defined($description) && $description =~ /\[default: (.*)\]/i) {
+        if (defined($description) && $description =~ /\[default: (.*?)\]/i) {
             $value = $1;
         }
     }

--- a/lib/Docopt.pm
+++ b/lib/Docopt.pm
@@ -188,7 +188,7 @@ sub value {
         # warn "SET: $_[0]";
         $self->{value} = $_[0];
     } else {
-        Carp::confess("Too much arguments");
+        Carp::confess("Too many arguments");
     }
 }
 
@@ -259,7 +259,7 @@ use Docopt::Util qw(repl class_name);
 
 sub new {
     my ($class, $children) = @_;
-    Carp::croak("Too much arguments") unless @_==2;
+    Carp::croak("Too many arguments") unless @_==2;
     Carp::confess "Children must be arrayref: $class, $children" unless ref $children eq 'ARRAY';
 
     # zjzj FIXME ad-hoc hack
@@ -277,7 +277,7 @@ sub children {
         ref($_[0]) eq 'ARRAY' or Carp::confess("Argument must be ArrayRef but: " . $_[0]);
         $self->{children} = $_[0];
     } else {
-        Carp::confess("Too much arguments");
+        Carp::confess("Too many arguments");
     }
 }
 
@@ -588,7 +588,7 @@ sub value {
         # Carp::cluck("SET: $_[0], $self->{long}, $self->{value}") if $_[0] eq 1;
         $self->{value} = $_[0];
     } else {
-        Carp::confess("Too much arguments");
+        Carp::confess("Too many arguments");
     }
 }
 
@@ -1182,7 +1182,7 @@ Docopt - Command-line interface description language
 
 =head1 DESCRIPTION
 
-B<Docopt.pm is still under development. I may change interface without notice.>
+B<Docopt.pm is still under development. The interface may change without notice.>
 
 Docopt is command-line interface description language.
 

--- a/t/unit.t
+++ b/t/unit.t
@@ -22,7 +22,7 @@ subtest 'transform' => sub {
     is_deeply(
         $got,
         Either(Required(Argument('<p>', None), Argument('<p>', None))),
-    ) or die repl($got); 
+    ) or die repl($got);
 };
 
 subtest 'fix_repeating_arguments' => sub {
@@ -31,7 +31,7 @@ subtest 'fix_repeating_arguments' => sub {
     is_deeply(
         $got,
         Required(OneOrMore(Optional(Argument('<p>', []))))
-    ) or die repl($got); 
+    ) or die repl($got);
 };
 
 subtest 'parse_section' => sub {


### PR DESCRIPTION
The regex updates add support for tabs in one place and restrict the [default: ] command to terminate at the first closing bracket.

The documentation changes should hopefully make the Pod support easier to use.